### PR TITLE
fix: revert override of goland package 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752603129,
-        "narHash": "sha256-S+wmHhwNQ5Ru689L2Gu8n1OD6s9eU9n9mD827JNR+kw=",
+        "lastModified": 1753761827,
+        "narHash": "sha256-mrVNT+aF4yR8P8Fx570W2vz+LzukSlf68Yr2YhUJHjo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8c19a3cec2814c754f031ab3ae7316b64da085b",
+        "rev": "50adf8fcaa97c9d64309f2d507ed8be54ea23110",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752480373,
-        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -1,11 +1,5 @@
 { config, pkgs, lib, ... }:
 
-let
-  alternateJetbrainsJdk = pkgs.jdk;
-  golandOverridden = pkgs.jetbrains.goland.override {
-    jdk = alternateJetbrainsJdk;
-  };
-in
 {
   # Home Manager needs a bit of information about you and the paths it should
   # manage.
@@ -32,11 +26,7 @@ in
     # # Adds the 'hello' command to your environment. It prints a friendly
     # # "Hello, world!" when run.
     # pkgs.hello
-
-    # FIXME: Restore the upstream package installation once the nix build is fixed upstream
-    # Refer: https://github.com/NixOS/nixpkgs/issues/425328
-    # pkgs.jetbrains.goland
-    golandOverridden
+    pkgs.jetbrains.goland
     pkgs.go
     pkgs.librewolf
     pkgs.bitwarden-desktop


### PR DESCRIPTION
Was previously unable to build, and the workaround was to provide an alternate JDK

refer: https://github.com/NixOS/nixpkgs/issues/425328